### PR TITLE
Atomic counters

### DIFF
--- a/atomic_counter.go
+++ b/atomic_counter.go
@@ -1,0 +1,100 @@
+package chotki
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/drpcorg/chotki/protocol"
+	"github.com/drpcorg/chotki/rdx"
+)
+
+var ErrNotCounter error = fmt.Errorf("not a counter")
+
+type AtomicCounter struct {
+	db           *Chotki
+	rid          rdx.ID
+	offset       uint64
+	localValue   atomic.Int64
+	tlv          atomic.Value
+	rdt          atomic.Value
+	loaded       atomic.Bool
+	lock         sync.Mutex
+	expiration   time.Time
+	updatePeriod time.Duration
+}
+
+// creates counter that has two properties
+//   - its atomic as long as you use single instance to do all increments, creating multiple instances will break this guarantee
+//   - it can ease CPU load if updatePeiod > 0, in that case it will not read from db backend
+//     current value of the counter
+//
+// Because we use LSM backend writes are cheap, reads are expensive. You can trade off up to date value of counter
+// for less CPU cycles
+func NewAtomicCounter(db *Chotki, rid rdx.ID, offset uint64, updatePeriod time.Duration) *AtomicCounter {
+	return &AtomicCounter{
+		db:           db,
+		rid:          rid,
+		offset:       offset,
+		updatePeriod: updatePeriod,
+	}
+}
+
+func (a *AtomicCounter) load() error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	now := time.Now()
+	if a.loaded.Load() && now.Sub(a.expiration) < 0 {
+		return nil
+	}
+	rdt, tlv, err := a.db.ObjectFieldTLV(a.rid.ToOff(a.offset))
+	if err != nil {
+		return err
+	}
+	a.rdt.Store(rdt)
+	a.loaded.Store(true)
+	a.tlv.Store(tlv)
+	switch rdt {
+	case rdx.ZCounter:
+		a.localValue.Store(rdx.Znative(tlv))
+	case rdx.Natural:
+		a.localValue.Store(int64(rdx.Nnative(tlv)))
+	default:
+		return ErrNotCounter
+	}
+	a.expiration = now.Add(a.updatePeriod)
+	return nil
+}
+
+// Loads (if needed) and increments counter
+func (a *AtomicCounter) Increment(ctx context.Context, val int64) (int64, error) {
+	err := a.load()
+	if err != nil {
+		return 0, err
+	}
+	if val == 2 {
+		fmt.Println(1)
+	}
+	rdt := a.rdt.Load().(byte)
+	a.localValue.Add(val)
+	var dtlv []byte
+	a.lock.Lock()
+	tlv := a.tlv.Load().([]byte)
+	switch rdt {
+	case rdx.Natural:
+		dtlv = rdx.Ndelta(tlv, uint64(a.localValue.Load()), a.db.Clock())
+	case rdx.ZCounter:
+		dtlv = rdx.Zdelta(tlv, a.localValue.Load(), a.db.Clock())
+	default:
+		return 0, ErrNotCounter
+	}
+	a.tlv.Store(dtlv)
+	a.lock.Unlock()
+	changes := make(protocol.Records, 0)
+	changes = append(changes, protocol.Record('F', rdx.ZipUint64(uint64(a.offset))))
+	changes = append(changes, protocol.Record(rdt, dtlv))
+	a.db.CommitPacket(ctx, 'E', a.rid, changes)
+	return a.localValue.Load(), nil
+}

--- a/atomic_counter_test.go
+++ b/atomic_counter_test.go
@@ -1,0 +1,119 @@
+package chotki
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/drpcorg/chotki/protocol"
+	"github.com/drpcorg/chotki/rdx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAtomicCounter(t *testing.T) {
+	dir, err := os.MkdirTemp("", "*")
+	assert.NoError(t, err)
+
+	a, err := Open(dir, Options{
+		Src:     0x1a,
+		Name:    "test replica",
+		Options: pebble.Options{ErrorIfExists: true},
+	})
+	assert.NoError(t, err)
+
+	cid, err := a.NewClass(context.Background(), rdx.ID0, Field{Name: "test", RdxType: rdx.Natural})
+	assert.NoError(t, err)
+
+	rid, err := a.NewObjectTLV(context.Background(), cid, protocol.Records{protocol.Record('N', rdx.Ntlv(0))})
+	assert.NoError(t, err)
+
+	counterA := NewAtomicCounter(a, rid, 1, 0)
+	counterB := NewAtomicCounter(a, rid, 1, 0)
+
+	res, err := counterA.Increment(context.Background(), 1)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, res)
+
+	res, err = counterB.Increment(context.Background(), 1)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 2, res)
+
+	res, err = counterA.Increment(context.Background(), 1)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 3, res)
+}
+
+func TestAtomicCounterWithPeriodicUpdate(t *testing.T) {
+	dira, err := os.MkdirTemp("", "*")
+	assert.NoError(t, err)
+
+	a, err := Open(dira, Options{
+		Src:     0x1a,
+		Name:    "test replica",
+		Options: pebble.Options{ErrorIfExists: true},
+	})
+	assert.NoError(t, err)
+
+	dirb, err := os.MkdirTemp("", "*")
+	assert.NoError(t, err)
+
+	b, err := Open(dirb, Options{
+		Src:     0x1b,
+		Name:    "test replica2",
+		Options: pebble.Options{ErrorIfExists: true},
+	})
+	assert.NoError(t, err)
+
+	cid, err := a.NewClass(
+		context.Background(), rdx.ID0,
+		Field{Name: "test", RdxType: rdx.Natural},
+		Field{Name: "test2", RdxType: rdx.ZCounter},
+	)
+	assert.NoError(t, err)
+
+	rid, err := a.NewObjectTLV(
+		context.Background(), cid,
+		protocol.Records{
+			protocol.Record('N', rdx.Ntlv(0)),
+			protocol.Record('Z', rdx.Ztlv(0)),
+		},
+	)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := 1; i <= 2; i++ {
+
+		counterA := NewAtomicCounter(a, rid, uint64(i), 100*time.Millisecond)
+		counterB := NewAtomicCounter(b, rid, uint64(i), 0)
+
+		// first increment
+		res, err := counterA.Increment(ctx, 1)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 1, res)
+
+		syncData(a, b)
+
+		// increment from another replica
+		res, err = counterB.Increment(ctx, 1)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 2, res)
+
+		syncData(a, b)
+
+		// this increment does not account data from other replica because current value is cached
+		res, err = counterA.Increment(ctx, 1)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 2, res)
+
+		time.Sleep(100 * time.Millisecond)
+
+		// after wait we increment, and we get actual value
+		res, err = counterA.Increment(ctx, 1)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 4, res)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/protocol/net_test.go
+++ b/protocol/net_test.go
@@ -98,7 +98,7 @@ func TestTCPDepot_Connect(t *testing.T) {
 	err = cCon.Drain(context.Background(), Records{Record('M', []byte("Hi there"))})
 	assert.Nil(t, err)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 	rec, err := lCon.Feed(context.Background())
 	assert.Nil(t, err)
 	assert.Greater(t, len(rec), 0)

--- a/sync.go
+++ b/sync.go
@@ -85,12 +85,13 @@ func (s SyncState) String() string {
 const TraceSize = 10
 
 type Syncer struct {
-	Src        uint64
-	Name       string
-	Host       SyncHost
-	Mode       SyncMode
-	PingPeriod time.Duration
-	PingWait   time.Duration
+	Src           uint64
+	Name          string
+	Host          SyncHost
+	Mode          SyncMode
+	PingPeriod    time.Duration
+	PingWait      time.Duration
+	WaitUntilNone time.Duration
 
 	log        utils.Logger
 	vvit, ffit *pebble.Iterator
@@ -267,7 +268,11 @@ func (sync *Syncer) Feed(ctx context.Context) (recs protocol.Records, err error)
 		sync.SetFeedState(ctx, SendNone)
 
 	case SendNone:
-		timer := time.AfterFunc(time.Second, func() {
+		wait := sync.WaitUntilNone
+		if wait == 0 {
+			wait = time.Second
+		}
+		timer := time.AfterFunc(wait, func() {
 			sync.SetDrainState(ctx, SendNone)
 		})
 		<-sync.WaitDrainState(context.Background(), SendNone)


### PR DESCRIPTION
Atomic counters that allow for 2 things
- Atomically update N/Z counter values
- Allow for caching of data to reduce reads. It makes counters less up to date (but eventually consistent), but reduces read frequency saving CPU cycles

Also fixed N/Z counters