### PR TITLE
fix: delete per-session prometheus gauge series on Syncer.Close

### DIFF
--- a/replication/sync.go
+++ b/replication/sync.go
@@ -126,8 +126,12 @@ type Syncer struct {
 	hostvv, peervv rdx.VV
 	vpack          []byte
 	reason         error
-	myTraceId      atomic.Pointer[[TraceSize]byte]
-	theirsTraceid  atomic.Pointer[[TraceSize]byte]
+	// set when a mid-session snapshot/iterator close failed, so Close()
+	// keeps the gauge series alive as the leak signal (guarded by lock)
+	snapCloseFailed bool
+	iterCloseFailed bool
+	myTraceId       atomic.Pointer[[TraceSize]byte]
+	theirsTraceid   atomic.Pointer[[TraceSize]byte]
 
 	lock      sync.Mutex
 	cond      sync.Cond
@@ -158,6 +162,13 @@ func (sync *Syncer) LogCtx(ctx context.Context) context.Context {
 func (sync *Syncer) Close() error {
 	sync.SetFeedState(context.Background(), SendNone)
 
+	// The id label is unique per connection, so keeping series around after
+	// the session ends leaks them until process restart. Drop the state
+	// series unconditionally; snapshot/iterator series are dropped below
+	// only when the underlying close succeeded, so a real leak stays visible.
+	defer SessionsStates.DeleteLabelValues(sync.Name, "feed", version)
+	defer SessionsStates.DeleteLabelValues(sync.Name, "drain", version)
+
 	if sync.Host == nil {
 		return utils.ErrClosed
 	}
@@ -165,16 +176,20 @@ func (sync *Syncer) Close() error {
 	sync.lock.Lock()
 	defer sync.lock.Unlock()
 
+	closesnapshot := !sync.snapCloseFailed
+
 	if sync.snap != nil {
 		if err := sync.snap.Close(); err != nil {
+			closesnapshot = false
 			sync.Log.ErrorCtx(sync.LogCtx(context.Background()), "failed closing snapshot", "err", err.Error())
-		} else {
-			OpenedSnapshots.WithLabelValues(sync.Name, version).Set(0)
 		}
 		sync.snap = nil
 	}
+	if closesnapshot {
+		OpenedSnapshots.DeleteLabelValues(sync.Name, version)
+	}
 
-	closediterators := true
+	closediterators := !sync.iterCloseFailed
 
 	if sync.ffit != nil {
 		if err := sync.ffit.Close(); err != nil {
@@ -192,7 +207,7 @@ func (sync *Syncer) Close() error {
 		sync.vvit = nil
 	}
 	if closediterators {
-		OpenedIterators.WithLabelValues(sync.Name, version).Set(0)
+		OpenedIterators.DeleteLabelValues(sync.Name, version)
 	}
 
 	sync.Log.InfoCtx(sync.LogCtx(context.Background()), fmt.Sprintf("sync: connection %s closed: %v\n", sync.Name, sync.reason))
@@ -258,6 +273,7 @@ func (sync *Syncer) Feed(ctx context.Context) (recs protocol.Records, err error)
 			if sync.snap != nil {
 				err = sync.snap.Close()
 				if err != nil {
+					sync.setSnapCloseFailed()
 					sync.Log.ErrorCtx(sync.LogCtx(ctx), "sync: failed closing snapshot", "err", err)
 				} else {
 					OpenedSnapshots.WithLabelValues(sync.Name, version).Set(0)
@@ -304,6 +320,7 @@ func (sync *Syncer) Feed(ctx context.Context) (recs protocol.Records, err error)
 		if sync.snap != nil {
 			err = sync.snap.Close()
 			if err != nil {
+				sync.setSnapCloseFailed()
 				sync.Log.ErrorCtx(sync.LogCtx(ctx), "sync: failed closing snapshot", "error", err.Error())
 			} else {
 				OpenedSnapshots.WithLabelValues(sync.Name, version).Set(0)
@@ -510,8 +527,22 @@ func (sync *Syncer) FeedDiffVV(ctx context.Context) (vv protocol.Records, err er
 	}
 	if closediterators {
 		OpenedIterators.WithLabelValues(sync.Name, version).Set(0)
+	} else {
+		sync.setIterCloseFailed()
 	}
 	return
+}
+
+func (sync *Syncer) setSnapCloseFailed() {
+	sync.lock.Lock()
+	sync.snapCloseFailed = true
+	sync.lock.Unlock()
+}
+
+func (sync *Syncer) setIterCloseFailed() {
+	sync.lock.Lock()
+	sync.iterCloseFailed = true
+	sync.lock.Unlock()
 }
 
 func (sync *Syncer) SetFeedState(ctx context.Context, state SyncState) {

--- a/replication/sync_metrics_test.go
+++ b/replication/sync_metrics_test.go
@@ -1,0 +1,136 @@
+package replication
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/drpcorg/chotki/protocol"
+	"github.com/drpcorg/chotki/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSyncHost struct{}
+
+func (f *fakeSyncHost) Drain(ctx context.Context, recs protocol.Records) error { return nil }
+func (f *fakeSyncHost) Snapshot() pebble.Reader                                { return nil }
+func (f *fakeSyncHost) Broadcast(ctx context.Context, recs protocol.Records, except string) {
+}
+
+// countSeries returns how many series of the vector carry the given session id label.
+func countSeries(t *testing.T, vec *prometheus.GaugeVec, id string) int {
+	t.Helper()
+	reg := prometheus.NewPedanticRegistry()
+	require.NoError(t, reg.Register(vec))
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	count := 0
+	for _, mf := range mfs {
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "id" && l.GetValue() == id {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+func TestCloseRemovesSessionMetricSeries(t *testing.T) {
+	name := "listen:test-close-removes-series"
+	syn := &Syncer{
+		Name: name,
+		Host: &fakeSyncHost{},
+		Log:  utils.NewDefaultLogger(slog.LevelError),
+	}
+
+	// Simulate what a live session does: state gauges for feed/drain,
+	// snapshot and iterator gauges from the handshake.
+	syn.SetFeedState(context.Background(), SendLive)
+	syn.SetDrainState(context.Background(), SendLive)
+	OpenedSnapshots.WithLabelValues(name, version).Set(1)
+	OpenedIterators.WithLabelValues(name, version).Set(1)
+
+	require.Equal(t, 2, countSeries(t, SessionsStates, name), "feed+drain series must exist before Close")
+	require.Equal(t, 1, countSeries(t, OpenedSnapshots, name))
+	require.Equal(t, 1, countSeries(t, OpenedIterators, name))
+
+	require.NoError(t, syn.Close())
+
+	require.Equal(t, 0, countSeries(t, SessionsStates, name), "session state series must be deleted on Close")
+	require.Equal(t, 0, countSeries(t, OpenedSnapshots, name), "snapshot series must be deleted on clean Close")
+	require.Equal(t, 0, countSeries(t, OpenedIterators, name), "iterator series must be deleted on clean Close")
+}
+
+type failingReader struct{}
+
+func (f *failingReader) Get(key []byte) (value []byte, closer io.Closer, err error) {
+	return nil, nil, pebble.ErrNotFound
+}
+func (f *failingReader) NewIter(o *pebble.IterOptions) (*pebble.Iterator, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *failingReader) Close() error { return errors.New("snapshot close failed") }
+
+func TestCloseKeepsSnapshotSeriesWhenSnapshotCloseFails(t *testing.T) {
+	name := "listen:test-close-snap-fail"
+	syn := &Syncer{
+		Name: name,
+		Host: &fakeSyncHost{},
+		Log:  utils.NewDefaultLogger(slog.LevelError),
+	}
+	syn.snap = &failingReader{}
+	OpenedSnapshots.WithLabelValues(name, version).Set(1)
+	t.Cleanup(func() { OpenedSnapshots.DeleteLabelValues(name, version) })
+	syn.SetFeedState(context.Background(), SendLive)
+
+	require.NoError(t, syn.Close())
+
+	require.Equal(t, 1, countSeries(t, OpenedSnapshots, name), "failed snapshot close must keep the leak signal")
+	require.Equal(t, 0, countSeries(t, SessionsStates, name))
+}
+
+func TestCloseKeepsSeriesAfterMidSessionCloseFailure(t *testing.T) {
+	name := "listen:test-close-mid-session-fail"
+	syn := &Syncer{
+		Name: name,
+		Host: &fakeSyncHost{},
+		Log:  utils.NewDefaultLogger(slog.LevelError),
+	}
+	// Simulate Feed()/FeedDiffVV() having failed to close the snapshot and
+	// iterators mid-session: the handles are nil'ed there, but the gauge
+	// series stay at 1 as the leak signal.
+	syn.snapCloseFailed = true
+	syn.iterCloseFailed = true
+	OpenedSnapshots.WithLabelValues(name, version).Set(1)
+	OpenedIterators.WithLabelValues(name, version).Set(1)
+	t.Cleanup(func() {
+		OpenedSnapshots.DeleteLabelValues(name, version)
+		OpenedIterators.DeleteLabelValues(name, version)
+	})
+
+	require.NoError(t, syn.Close())
+
+	require.Equal(t, 1, countSeries(t, OpenedSnapshots, name), "mid-session snapshot close failure must keep the leak signal")
+	require.Equal(t, 1, countSeries(t, OpenedIterators, name), "mid-session iterator close failure must keep the leak signal")
+}
+
+func TestCloseWithNilHostStillRemovesSessionSeries(t *testing.T) {
+	name := "listen:test-close-nil-host"
+	syn := &Syncer{
+		Name: name,
+		Log:  utils.NewDefaultLogger(slog.LevelError),
+	}
+
+	syn.SetFeedState(context.Background(), SendLive)
+	require.Equal(t, 1, countSeries(t, SessionsStates, name))
+
+	require.Error(t, syn.Close()) // nil Host reports ErrClosed, but must not leak series
+
+	require.Equal(t, 0, countSeries(t, SessionsStates, name), "series must be deleted even on the nil-Host path")
+}


### PR DESCRIPTION
## Problem

The gauges `chotki_sync_sessions` (labels `id`, `kind`, `version`), `chotki_sync_opened_snapshots` and `chotki_sync_opened_iterators` (labels `id`, `version`) use the connection name as the `id` label. Listen-side names (`listen:<uuid>:<ip>:<port>`) are unique per connection, and the series were never removed when a session terminated — they accumulate until the process restarts.

Observed on a long-running production deployment (2026-07-05): **84,320 stale `chotki_sync_sessions` series in state 4 (SendNone)** vs 135 live sessions; long-lived nodes exposed ~46k samples per `/metrics` scrape vs ~10k on freshly-restarted ones. Unbounded label cardinality like this eventually pushes `/metrics` past scraper response-size limits, at which point the entire scrape gets dropped silently.

## Fix

`Syncer.Close()` now deletes the per-session series. `network.Peer.Close()` calls it only after `wg.Wait()` has joined the read/write loops, so no `Feed`/`Drain` runs concurrently with the deletion (and a straggler double-`Close` is self-cleaning because the deletes are deferred to function exit).

One subtlety: alerting on leaked pebble resources relies on `opened_snapshots`/`opened_iterators` staying nonzero when a close fails. Deleting those series unconditionally would blind it. So:

- `chotki_sync_sessions` (feed + drain) series are always deleted, including the nil-Host early-return path.
- Snapshot/iterator series are deleted only when every close succeeded. Mid-session close failures in `Feed()` (SendDiff/SendEOF paths) and `FeedDiffVV()` nil the handles while leaving the gauge at 1, so new `snapCloseFailed`/`iterCloseFailed` flags (set under the lock) tell `Close()` to keep those series as the leak signal.

## Testing

New white-box tests in `replication/sync_metrics_test.go`: clean close removes all per-session series; close with a failing snapshot keeps the snapshot series; mid-session close failure (flags set) keeps snapshot+iterator series; nil-Host close still removes state series. Full `go test ./...` passes.

## Review notes

Both reviewers noted that `Feed`/`FeedDiffVV` mutate `snap`/`ffit`/`vvit` outside `sync.lock` while `Close()` reads them under it — that is pre-existing behavior, safe under the current `Peer.Close` ordering guarantee, and left untouched to keep this change minimal. Related follow-up candidate (not in this PR): `chotki_outbound_packet_count` (CounterVec, per-peer `name` label) leaks series the same way.
